### PR TITLE
rerender

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,6 @@
 version: 2
 
 jobs:
-  build__CONDA_R_3.3.2:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONDA_R: "3.3.2"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./ci_support/fast_finish_ci_pr_build.sh
-            ./ci_support/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          name: Print conda-build environment variables
-          command: |
-            echo "CONDA_R=${CONDA_R}"
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./ci_support/run_docker_build.sh
   build__CONDA_R_3.4.1:
     working_directory: ~/test
     machine: true
@@ -48,5 +27,4 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build__CONDA_R_3.3.2
       - build__CONDA_R_3.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ osx_image: xcode6.4
 env:
   matrix:
     
-    - CONDA_R=3.3.2
     - CONDA_R=3.4.1
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.


### PR DESCRIPTION
Cannot build for `r-base 3.3.2` b/c of the outdated pinning for that version and the one used to build `gdal`.