### PR TITLE
Explicit`geos` dependency

### DIFF
--- a/.ci_support/linux_64_r_base4.1.yaml
+++ b/.ci_support/linux_64_r_base4.1.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,9 +13,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/linux_64_r_base4.2.yaml
+++ b/.ci_support/linux_64_r_base4.2.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,9 +13,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_r_base4.1.yaml
+++ b/.ci_support/linux_aarch64_r_base4.1.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,9 +17,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/linux_aarch64_r_base4.2.yaml
+++ b/.ci_support/linux_aarch64_r_base4.2.yaml
@@ -3,7 +3,7 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -17,9 +17,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_r_base4.1.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.1.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,9 +13,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/linux_ppc64le_r_base4.2.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.2.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
 cdt_name:
 - cos7
 channel_sources:
@@ -13,9 +13,11 @@ cran_mirror:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 pin_run_as_build:

--- a/.ci_support/osx_64_r_base4.1.yaml
+++ b/.ci_support/osx_64_r_base4.1.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,9 @@ cran_mirror:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 macos_machine:

--- a/.ci_support/osx_64_r_base4.2.yaml
+++ b/.ci_support/osx_64_r_base4.2.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +13,9 @@ cran_mirror:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
+geos:
+- 3.11.1
 libgdal:
 - '3.6'
 macos_machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   merge_build_host: true  # [win]
   skip: true  # [win]
-  number: 0
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - r-rcpp >=0.12.18
     - r-s2 >=1.1.0
     - r-units >=0.7_0
+    - geos     # [not win]
     - libgdal  # [not win]
     - proj     # [not win]
   run:
@@ -56,8 +57,6 @@ requirements:
     - r-rcpp >=0.12.18
     - r-s2 >=1.1.0
     - r-units >=0.7_0
-    - libgdal  # [not win]
-    - proj  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
GEOS is linked against but not declared. The PROJ920 migration needs to have GEOS migrated to 3.12 first, but we first need to have GEOS explicit to trigger such a migration.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
