### PR TITLE
use libgdal-core instead of libgdal

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,27 +11,27 @@ jobs:
       linux_64_r_base4.3:
         CONFIG: linux_64_r_base4.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_64_r_base4.4:
         CONFIG: linux_64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_aarch64_r_base4.3:
         CONFIG: linux_aarch64_r_base4.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_aarch64_r_base4.4:
         CONFIG: linux_aarch64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_ppc64le_r_base4.3:
         CONFIG: linux_ppc64le_r_base4.3
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
       linux_ppc64le_r_base4.4:
         CONFIG: linux_ppc64le_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -27,6 +27,7 @@ jobs:
       displayName: Run Windows build
       env:
         MINIFORGE_HOME: $(MINIFORGE_HOME)
+        CONDA_BLD_PATH: $(CONDA_BLD_PATH)
         PYTHONUNBUFFERED: 1
         CONFIG: $(CONFIG)
         CI: azure

--- a/.ci_support/linux_64_r_base4.3.yaml
+++ b/.ci_support/linux_64_r_base4.3.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.3.yaml
+++ b/.ci_support/linux_aarch64_r_base4.3.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -1,5 +1,3 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 c_compiler:
 - gcc
 c_compiler_version:
@@ -8,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - conda
 channel_sources:
@@ -23,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_ppc64le_r_base4.3.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.3.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/linux_ppc64le_r_base4.4.yaml
+++ b/.ci_support/linux_ppc64le_r_base4.4.yaml
@@ -19,10 +19,10 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/osx_64_r_base4.3.yaml
+++ b/.ci_support/osx_64_r_base4.3.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_64_r_base4.4.yaml
+++ b/.ci_support/osx_64_r_base4.4.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - x86_64-apple-darwin13.4.0

--- a/.ci_support/osx_arm64_r_base4.3.yaml
+++ b/.ci_support/osx_arm64_r_base4.3.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -22,7 +22,7 @@ cxx_compiler_version:
 - '18'
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 macos_machine:
 - arm64-apple-darwin20.0.0

--- a/.ci_support/win_64_r_base4.3.yaml
+++ b/.ci_support/win_64_r_base4.3.yaml
@@ -8,7 +8,7 @@ cran_mirror:
 - https://cran.r-project.org
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.ci_support/win_64_r_base4.4.yaml
+++ b/.ci_support/win_64_r_base4.4.yaml
@@ -8,7 +8,7 @@ cran_mirror:
 - https://cran.r-project.org
 geos:
 - 3.13.0
-libgdal:
+libgdal_core:
 - '3.10'
 pin_run_as_build:
   r-base:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -6,8 +6,9 @@ source .scripts/logging_utils.sh
 
 set -xe
 
-MINIFORGE_HOME=${MINIFORGE_HOME:-${HOME}/miniforge3}
-MINIFORGE_HOME=${MINIFORGE_HOME%/} # remove trailing slash
+MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
+MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
+export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
 
 ( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
 MICROMAMBA_VERSION="1.5.10-0"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -36,6 +36,7 @@ if !errorlevel! neq 0 exit /b !errorlevel!
 echo Removing %MAMBA_ROOT_PREFIX%
 del /S /Q "%MAMBA_ROOT_PREFIX%" >nul
 del /S /Q "%MICROMAMBA_TMPDIR%" >nul
+call :end_group
 
 call :start_group "Configuring conda"
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - '*/R.dll'           # [win]
     - '*/Rblas.dll'       # [win]
     - '*/Rlapack.dll'     # [win]
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     - r-s2 >=1.1.0
     - r-units >=0.7_0
     - geos
-    - libgdal
+    - libgdal-core
     - proj
   run:
     - r-base


### PR DESCRIPTION
As suggested in https://github.com/conda-forge/r-sf-feedstock/issues/137, it seems that we only need `libgdal-core` instead of the full `libgdal` with all the plugins.  Switching `libgdal-core` would significantly reduce the dependency footprint of `r-sf`, which is currently quite heavy, even though it seems `r-sf` itself only uses functionality from `libgdal-core`.