### PR TITLE
Backward-compatible builds without latest geos, proj migrations

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,19 +11,19 @@ jobs:
       linux_64_r_base4.4:
         CONFIG: linux_64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_r_base4.5:
         CONFIG: linux_64_r_base4.5
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_r_base4.4:
         CONFIG: linux_aarch64_r_base4.4
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_r_base4.5:
         CONFIG: linux_aarch64_r_base4.5
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:cos7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.1
 libgdal_core:

--- a/.ci_support/linux_64_r_base4.4.yaml
+++ b/.ci_support/linux_64_r_base4.4.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -29,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.4'
 target_platform:

--- a/.ci_support/linux_64_r_base4.5.yaml
+++ b/.ci_support/linux_64_r_base4.5.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.1
 libgdal_core:

--- a/.ci_support/linux_64_r_base4.5.yaml
+++ b/.ci_support/linux_64_r_base4.5.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -29,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.5'
 target_platform:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.1
 libgdal_core:

--- a/.ci_support/linux_aarch64_r_base4.4.yaml
+++ b/.ci_support/linux_aarch64_r_base4.4.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -29,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.4'
 target_platform:

--- a/.ci_support/linux_aarch64_r_base4.5.yaml
+++ b/.ci_support/linux_aarch64_r_base4.5.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:cos7
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 geos:
 - 3.13.1
 libgdal_core:

--- a/.ci_support/linux_aarch64_r_base4.5.yaml
+++ b/.ci_support/linux_aarch64_r_base4.5.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -21,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:cos7
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -29,7 +27,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.5'
 target_platform:

--- a/.ci_support/migrations/geos3140.yaml
+++ b/.ci_support/migrations/geos3140.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for geos 3.14.0
-  kind: version
-  migration_number: 1
-geos:
-- 3.14.0
-migrator_ts: 1755854476.6168127

--- a/.ci_support/migrations/proj97.yaml
+++ b/.ci_support/migrations/proj97.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for proj 9.7
-  kind: version
-  migration_number: 1
-migrator_ts: 1757934925.365837
-proj:
-- '9.7'

--- a/.ci_support/osx_64_r_base4.4.yaml
+++ b/.ci_support/osx_64_r_base4.4.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 macos_machine:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.4'
 target_platform:

--- a/.ci_support/osx_64_r_base4.5.yaml
+++ b/.ci_support/osx_64_r_base4.5.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 macos_machine:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.5'
 target_platform:

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 macos_machine:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.4'
 target_platform:

--- a/.ci_support/osx_arm64_r_base4.5.yaml
+++ b/.ci_support/osx_arm64_r_base4.5.yaml
@@ -21,7 +21,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 macos_machine:
@@ -31,7 +31,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.5'
 target_platform:

--- a/.ci_support/win_64_r_base4.4.yaml
+++ b/.ci_support/win_64_r_base4.4.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cran_mirror:
 - https://cran.r-project.org
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -15,7 +15,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.4'
 target_platform:

--- a/.ci_support/win_64_r_base4.5.yaml
+++ b/.ci_support/win_64_r_base4.5.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cran_mirror:
 - https://cran.r-project.org
 geos:
-- 3.14.0
+- 3.13.1
 libgdal_core:
 - '3.11'
 pin_run_as_build:
@@ -15,7 +15,7 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 proj:
-- '9.7'
+- '9.6'
 r_base:
 - '4.5'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -229,7 +229,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/r-sf-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,8 +10,6 @@ conda_forge_output_validation: true
 github:
   branch_name: main
   tooling_branch_name: main
-os_version:
-  linux_64: cos7
 provider:
   linux_aarch64: default
   linux_ppc64le: default

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,9 @@ requirements:
     - r-rcpp                       # [build_platform != target_platform]
     - r-s2                         # [build_platform != target_platform]
     - r-units                      # [build_platform != target_platform]
+    - r-sp                         # [build_platform != target_platform]
+    - r-matrix                     # [build_platform != target_platform]
+    - r-rpostgresql                # [build_platform != target_platform]
     - {{ compiler('c') }}          # [not win]
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}        # [not win]
@@ -55,6 +58,9 @@ requirements:
     - r-rcpp >=0.12.18
     - r-s2 >=1.1.0
     - r-units >=0.7_0
+    - r-sp
+    - r-matrix
+    - r-rpostgresql
     - geos
     - libgdal-core
     - proj

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,6 @@ requirements:
     - r-rcpp                       # [build_platform != target_platform]
     - r-s2                         # [build_platform != target_platform]
     - r-units                      # [build_platform != target_platform]
-    - r-sp                         # [build_platform != target_platform]
-    - r-matrix                     # [build_platform != target_platform]
-    - r-rpostgresql                # [build_platform != target_platform]
     - {{ compiler('c') }}          # [not win]
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}        # [not win]
@@ -58,9 +55,6 @@ requirements:
     - r-rcpp >=0.12.18
     - r-s2 >=1.1.0
     - r-units >=0.7_0
-    - r-sp
-    - r-matrix
-    - r-rpostgresql
     - geos
     - libgdal-core
     - proj

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
     - '*/R.dll'           # [win]
     - '*/Rblas.dll'       # [win]
     - '*/Rlapack.dll'     # [win]
-  number: 1
+  number: 2
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
I am attempting this because we are seeing solving issues with `r-sf` and conjecture it may be connected with combining other unfinished migrations into the R 4.5 migration. This defaults to cf-pinnings (other than R 4.5).

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
